### PR TITLE
Fix TopIconsPlus not working with GNOME 3.30

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -177,7 +177,13 @@ function createTray() {
     tray = new Shell.TrayManager();
     tray.connect('tray-icon-added', onTrayIconAdded);
     tray.connect('tray-icon-removed', onTrayIconRemoved);
-    tray.manage_screen(global.screen, Main.panel.actor);
+    if (global.hasOwnProperty("screen")) {
+        // For GNOME 3.28 and older
+        tray.manage_screen(global.screen, Main.panel.actor);
+    } else {
+        // For GNOME 3.30+
+        tray.manage_screen(Main.panel.actor);
+    }
     placeTray();
 }
 


### PR DESCRIPTION
GNOME 3.30 has removed the use of mutter's MetaScreen, see e.g. :
https://gitlab.gnome.org/GNOME/gnome-shell-extensions/commit/6583eae6225039b6b711918eff3a7cd0d03a42ca
and:
https://bugzilla.gnome.org/show_bug.cgi?id=759538

This commit implements support for TopIconsPlus to work with the new
Shell.TrayManager.manage_screen prototype which takes only 1 argument.

I've implemented this using hasOwnProperty so that things should keep
working with older GNOME3 versions.

Signed-off-by: Hans de Goede <hdegoede@redhat.com>